### PR TITLE
Fix Troubleshooting link

### DIFF
--- a/.github/workflows/grading.yml
+++ b/.github/workflows/grading.yml
@@ -19,4 +19,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: troubleshooting steps
-        run: echo "If you're stuck this documentation may be helpful, https://docs.github.com/en/actions/reference/encrypted-secrets."
+        run: echo "If you're stuck, this documentation may be helpful; https://docs.github.com/en/actions/reference/encrypted-secrets"


### PR DESCRIPTION
This removes a `.` at the end of the helpful documentation link in the troubleshooting message. The period was breaking the URL. 